### PR TITLE
Add pathroutr fork to packages.json

### DIFF
--- a/packages.json
+++ b/packages.json
@@ -90,5 +90,9 @@
     {
         "package": "wcUtils",
         "url": "https://github.com/noaa-afsc/wcUtils"
+    },
+    {
+        "package": "pathroutr",
+        "url": "https://github.com/mhpob/pathroutr"
     }
 ]


### PR DESCRIPTION
A PR has been sent into the main pathroutr repo, but asking for this fork to be added (hopefully temporarily) to use in downstream development.